### PR TITLE
feat(handler): Allow specifying subsystem and category in Handler

### DIFF
--- a/pyoslog/core.py
+++ b/pyoslog/core.py
@@ -1,5 +1,5 @@
 from ctypes import py_object
-from typing import Any
+from typing import Any, Optional
 
 try:
     import _pyoslog  # type: ignore
@@ -24,7 +24,12 @@ _os_log_t_native_type = py_object
 
 # noinspection PyPep8Naming
 class os_log_t:
-    def __init__(self, log_object: _os_log_t_native_type, subsystem: str, category: str) -> None:
+    def __init__(
+        self,
+        log_object: _os_log_t_native_type,
+        subsystem: Optional[str],
+        category: Optional[str],
+    ) -> None:
         self._log_object = log_object
         self._subsystem = subsystem
         self._category = category

--- a/pyoslog/core.py
+++ b/pyoslog/core.py
@@ -1,5 +1,5 @@
 from ctypes import py_object
-from typing import Any, Optional
+from typing import Any
 
 try:
     import _pyoslog  # type: ignore
@@ -24,12 +24,7 @@ _os_log_t_native_type = py_object
 
 # noinspection PyPep8Naming
 class os_log_t:
-    def __init__(
-        self,
-        log_object: _os_log_t_native_type,
-        subsystem: Optional[str],
-        category: Optional[str],
-    ) -> None:
+    def __init__(self, log_object: _os_log_t_native_type, subsystem: str, category: str) -> None:
         self._log_object = log_object
         self._subsystem = subsystem
         self._category = category

--- a/pyoslog/handler.py
+++ b/pyoslog/handler.py
@@ -12,9 +12,9 @@ class Handler(logging.Handler):
     is converted to the matching pyoslog.OS_LOG_TYPE_* type, and messages outputted to the unified log."""
 
     def __init__(
-        self, subsystem: Optional[str] = None, category: Optional[str] = None
+        self, subsystem: Optional[str] = None, category: str = 'default'
     ) -> None:
-        """Initialise a Handler instance.
+        """Initialise a Handler instance, logging at OS_LOG_TYPE_DEFAULT
 
         If a subsystem is provided, a custom os_log object is created using that subsystem.
         If a category is also provided, it will be used; otherwise, 'default' is used as the category name.
@@ -27,12 +27,9 @@ class Handler(logging.Handler):
                                       Defaults to 'default' if subsystem is provided but category is None.
         """
         logging.Handler.__init__(self)
+        self._log_object = OS_LOG_DEFAULT
         if subsystem is not None:
-            self._log_object = os_log_create(
-                subsystem, category if category is not None else 'default'
-            )
-        else:
-            self._log_object = OS_LOG_DEFAULT
+            self.setSubsystem(subsystem, category=category)
 
     @staticmethod
     def _get_pyoslog_type(level: int) -> int:

--- a/pyoslog/handler.py
+++ b/pyoslog/handler.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Optional
 
 from .core import *
 
@@ -10,10 +11,28 @@ class Handler(logging.Handler):
     """This logging Handler forwards all messages to pyoslog. The logging level (set as normal via :py:func:`setLevel`)
     is converted to the matching pyoslog.OS_LOG_TYPE_* type, and messages outputted to the unified log."""
 
-    def __init__(self) -> None:
-        """Initialise a Handler instance, logging to OS_LOG_DEFAULT at OS_LOG_TYPE_DEFAULT"""
+    def __init__(
+        self, subsystem: Optional[str] = None, category: Optional[str] = None
+    ) -> None:
+        """Initialise a Handler instance.
+
+        If a subsystem is provided, a custom os_log object is created using that subsystem.
+        If a category is also provided, it will be used; otherwise, 'default' is used as the category name.
+        If no subsystem is provided, OS_LOG_DEFAULT is used, and the category parameter is ignored.
+
+        Args:
+            subsystem (Optional[str]): The subsystem for os_log (e.g., 'com.example.myapp').
+                                       If None, OS_LOG_DEFAULT is used.
+            category (Optional[str]): The category for os_log. Used only if subsystem is not None.
+                                      Defaults to 'default' if subsystem is provided but category is None.
+        """
         logging.Handler.__init__(self)
-        self._log_object = OS_LOG_DEFAULT
+        if subsystem is not None:
+            self._log_object = os_log_create(
+                subsystem, category if category is not None else 'default'
+            )
+        else:
+            self._log_object = OS_LOG_DEFAULT
 
     @staticmethod
     def _get_pyoslog_type(level: int) -> int:

--- a/pyoslog/handler.py
+++ b/pyoslog/handler.py
@@ -12,7 +12,7 @@ class Handler(logging.Handler):
     is converted to the matching pyoslog.OS_LOG_TYPE_* type, and messages outputted to the unified log."""
 
     def __init__(
-        self, subsystem: Optional[str] = None, category: str = 'default'
+            self, subsystem: Optional[str] = None, category: str = 'default'
     ) -> None:
         """Initialise a Handler instance, logging at OS_LOG_TYPE_DEFAULT
 

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -36,21 +36,17 @@ class TestHandler(unittest.TestCase):
                 print(skip_reason)
                 raise unittest.SkipTest(skip_reason)
 
-        subsystem_handler = pyoslog.Handler(
-            subsystem=pyoslog_test_globals.LOG_SUBSYSTEM
-        )
+        subsystem_handler = pyoslog.Handler(subsystem=pyoslog_test_globals.LOG_SUBSYSTEM)
         self.assertIsInstance(subsystem_handler._log_object, pyoslog_core.os_log_t)
         self.assertEqual(str(subsystem_handler._log_object), '<os_log_t (%s:%s)>' % (pyoslog_test_globals.LOG_SUBSYSTEM,
                                                                                      'default'))
         self.assertEqual(subsystem_handler.level, logging.NOTSET)
 
-        category_handler = pyoslog.Handler(
-            subsystem=pyoslog_test_globals.LOG_SUBSYSTEM,
-            category=pyoslog_test_globals.LOG_CATEGORY,
-        )
+        category_handler = pyoslog.Handler(subsystem=pyoslog_test_globals.LOG_SUBSYSTEM,
+                                           category=pyoslog_test_globals.LOG_CATEGORY)
         self.assertIsInstance(category_handler._log_object, pyoslog_core.os_log_t)
         self.assertEqual(str(category_handler._log_object), '<os_log_t (%s:%s)>' % (pyoslog_test_globals.LOG_SUBSYSTEM,
-                                                                                    pyoslog_test_globals.LOG_CATEGORY),)
+                                                                                    pyoslog_test_globals.LOG_CATEGORY))
         self.assertEqual(category_handler.level, logging.NOTSET)
 
         # specifying a category without a subsystem is ignored

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -36,6 +36,27 @@ class TestHandler(unittest.TestCase):
                 print(skip_reason)
                 raise unittest.SkipTest(skip_reason)
 
+        subsystem_handler = pyoslog.Handler(
+            subsystem=pyoslog_test_globals.LOG_SUBSYSTEM
+        )
+        self.assertIsInstance(subsystem_handler._log_object, pyoslog_core.os_log_t)
+        self.assertEqual(str(subsystem_handler._log_object), '<os_log_t (%s:%s)>' % (pyoslog_test_globals.LOG_SUBSYSTEM,
+                                                                                     'default'))
+        self.assertEqual(subsystem_handler.level, logging.NOTSET)
+
+        category_handler = pyoslog.Handler(
+            subsystem=pyoslog_test_globals.LOG_SUBSYSTEM,
+            category=pyoslog_test_globals.LOG_CATEGORY,
+        )
+        self.assertIsInstance(category_handler._log_object, pyoslog_core.os_log_t)
+        self.assertEqual(str(category_handler._log_object), '<os_log_t (%s:%s)>' % (pyoslog_test_globals.LOG_SUBSYSTEM,
+                                                                                    pyoslog_test_globals.LOG_CATEGORY),)
+        self.assertEqual(category_handler.level, logging.NOTSET)
+
+        # specifying a category without a subsystem is ignored
+        no_subsystem_handler = pyoslog.Handler(category=pyoslog_test_globals.LOG_CATEGORY)
+        self.assertEqual(no_subsystem_handler._log_object, pyoslog.OS_LOG_DEFAULT)
+
         self.handler = pyoslog.Handler()
         self.assertEqual(self.handler._log_object, pyoslog.OS_LOG_DEFAULT)
         self.assertEqual(self.handler.level, logging.NOTSET)

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -108,7 +108,7 @@ class TestLogging(unittest.TestCase):
             # Console.app is live-streaming logs
             if pyoslog.os_log_type_enabled(pyoslog.OS_LOG_DEFAULT, log_type.value):
                 self.assertIn('_pyoslog', received_message.sender())
-                self.assertIn('python', received_message.process())
+                self.assertIn('python', received_message.process().lower())
                 self.assertEqual(pyoslog_test_globals.oslog_level_to_type(received_message.level()), log_type)
                 self.assertIsNone(received_message.subsystem())
                 self.assertIsNone(received_message.category())
@@ -133,7 +133,7 @@ class TestLogging(unittest.TestCase):
             # (but not via Python) and viewed via, e.g., `sudo log config --status --subsystem 'ac.robinson.pyoslog'`
             if pyoslog.os_log_type_enabled(self.log, log_type.value):
                 self.assertIn('_pyoslog', received_message.sender())
-                self.assertIn('python', received_message.process())
+                self.assertIn('python', received_message.process().lower())
                 self.assertEqual(pyoslog_test_globals.oslog_level_to_type(received_message.level()), log_type)
                 self.assertEqual(received_message.subsystem(), pyoslog_test_globals.LOG_SUBSYSTEM)
                 self.assertEqual(received_message.category(), pyoslog_test_globals.LOG_CATEGORY)


### PR DESCRIPTION
The Handler class now accepts optional subsystem and category arguments in its constructor, to allow setting them from `logging.config.dictConfig()`